### PR TITLE
#188271985 feat(utility): implement array comparison utility function

### DIFF
--- a/src/areArraysEqual/index.ts
+++ b/src/areArraysEqual/index.ts
@@ -1,0 +1,48 @@
+import { deepClone } from '../commons/deepClone';
+import { findAndPop } from '../commons/findAndPop';
+
+/**
+ * Checks if two arrays are equal.
+ * @param array1 The first array.
+ * @param array2 The second array.
+ * @param strictMode If true, performs a strict comparison of array elements.
+ * @returns True if the arrays are equal, false otherwise.
+ */
+export function areArraysEqual<T>(
+  array1: T[],
+  array2: T[],
+  strictMode = false
+): boolean {
+  // Check if the arrays have different lengths
+  if (array1.length !== array2.length) {
+    return false;
+  }
+
+  if (strictMode) {
+    // Perform strict comparison of array elements
+    for (let i = 0; i < array1.length; i++) {
+      if (typeof array1[i] !== typeof array2[i]) {
+        return false;
+      } else if (array1[i] !== array2[i]) {
+        return false;
+      }
+    }
+  } else {
+    // Perform loose comparison of array elements
+    const clonedArr1 = deepClone(array1);
+    const clonedArr2 = deepClone(array2);
+
+    while (clonedArr1.length) {
+      const topElement = clonedArr1.pop();
+      const twinElement = findAndPop(clonedArr2, topElement);
+
+      if (!twinElement) {
+        // If an element is missing in the second array, the arrays are not equal
+        return false;
+      }
+    }
+  }
+
+  // The arrays are equal
+  return true;
+}

--- a/src/areArraysEqual/test/index.spec.ts
+++ b/src/areArraysEqual/test/index.spec.ts
@@ -1,0 +1,65 @@
+import { areArraysEqual } from '..';
+
+describe('areArraysEqual', () => {
+  it('should return true for equal arrays', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [1, 2, 3];
+    expect(areArraysEqual(array1, array2)).toBe(true);
+  });
+
+  it('should return false for arrays with different lengths', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [1, 2];
+    expect(areArraysEqual(array1, array2)).toBe(false);
+  });
+
+  it('should return false for arrays with different elements', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [1, 4, 3];
+    expect(areArraysEqual(array1, array2)).toBe(false);
+  });
+
+  it('should return true for equal arrays in strict mode', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [1, 2, 3];
+    expect(areArraysEqual(array1, array2, true)).toBe(true);
+  });
+
+  it('should return false for arrays with different types in strict mode', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [1, '2', 3];
+    expect(areArraysEqual(array1, array2, true)).toBe(false);
+  });
+
+  it('should return false for arrays with different elements in strict mode', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [1, 4, 3];
+    expect(areArraysEqual(array1, array2, true)).toBe(false);
+  });
+
+  it('should return true for equal arrays of objects', () => {
+    const array1 = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Jane' },
+    ];
+    const array2 = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Jane' },
+    ];
+    const result = areArraysEqual(array1, array2);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for different arrays of objects', () => {
+    const array1 = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Jane' },
+    ];
+    const array2 = [
+      { id: 1, name: 'John' },
+      { id: 3, name: 'Alice' },
+    ];
+    const result = areArraysEqual(array1, array2);
+    expect(result).toBe(false);
+  });
+});

--- a/src/areObjectsEqual/index.ts
+++ b/src/areObjectsEqual/index.ts
@@ -1,3 +1,5 @@
+import { areArraysEqual } from '../areArraysEqual';
+
 export function areObjectsEqual<T1, T2>(obj1: T1, obj2: T2): boolean {
   // Handle strict equality and special cases
   if (Object.is(obj1, obj2)) return true;
@@ -12,10 +14,7 @@ export function areObjectsEqual<T1, T2>(obj1: T1, obj2: T2): boolean {
   // Handle array comparison
   if (Array.isArray(obj1) && Array.isArray(obj2)) {
     if (obj1.length !== obj2.length) return false;
-    for (let i = 0; i < obj1.length; i++) {
-      if (!areObjectsEqual(obj1[i], obj2[i])) return false;
-    }
-    return true;
+    return areArraysEqual(obj1, obj2);
   }
 
   // Handle object comparison

--- a/src/commons/deepClone.ts
+++ b/src/commons/deepClone.ts
@@ -1,0 +1,23 @@
+// Function to deep clone an object
+export function deepClone<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    const arrCopy = [];
+    for (const item of obj) {
+      arrCopy.push(deepClone(item));
+    }
+    return arrCopy as unknown as T;
+  }
+
+  const objCopy: { [K in keyof T]: T[K] } = {} as { [K in keyof T]: T[K] };
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      objCopy[key] = deepClone(obj[key]);
+    }
+  }
+
+  return objCopy as T;
+}

--- a/src/commons/findAndPop.ts
+++ b/src/commons/findAndPop.ts
@@ -1,0 +1,20 @@
+import { areObjectsEqual } from '../areObjectsEqual';
+import { isObject } from './isObject';
+
+export function findAndPop<T>(arr: T[], element: T): T | null {
+  const index = arr.findIndex(el => {
+    if (isObject(el) && isObject(element)) {
+      return areObjectsEqual(el, element);
+    } else {
+      return element === el;
+    }
+  });
+
+  if (index !== -1) {
+    const result = arr[index];
+    arr.splice(index, 1);
+    return result;
+  }
+
+  return null;
+}

--- a/src/commons/index.ts
+++ b/src/commons/index.ts
@@ -1,0 +1,4 @@
+export { deepClone } from './deepClone';
+export { findAndPop } from './findAndPop';
+export { isObject } from './isObject';
+export { isPrimitive } from './isPrimitive';

--- a/src/commons/isObject.ts
+++ b/src/commons/isObject.ts
@@ -1,0 +1,2 @@
+export const isObject = (obj: unknown): obj is Record<string, unknown> =>
+  obj !== null && typeof obj === 'object' && !Array.isArray(obj);

--- a/src/commons/isPrimitive.ts
+++ b/src/commons/isPrimitive.ts
@@ -1,0 +1,12 @@
+export function isPrimitive(value: unknown): boolean {
+  const type = typeof value;
+  return (
+    value === null ||
+    type === 'boolean' ||
+    type === 'number' ||
+    type === 'string' ||
+    type === 'symbol' ||
+    type === 'undefined' ||
+    type === 'bigint'
+  );
+}

--- a/src/commons/test/deepClone.spec.ts
+++ b/src/commons/test/deepClone.spec.ts
@@ -1,0 +1,31 @@
+import { deepClone } from '../';
+
+describe('deepClone', () => {
+  it('should clone a simple object', () => {
+    const obj = { a: 1 };
+    const clone = deepClone(obj);
+    expect(clone).toEqual(obj);
+    expect(clone).not.toBe(obj);
+  });
+
+  it('should clone a nested object', () => {
+    const obj = { a: { b: 1 } };
+    const clone = deepClone(obj);
+    expect(clone).toEqual(obj);
+    expect(clone.a).not.toBe(obj.a);
+  });
+
+  it('should clone an array', () => {
+    const arr = [1, 2, 3];
+    const clone = deepClone(arr);
+    expect(clone).toEqual(arr);
+    expect(clone).not.toBe(arr);
+  });
+
+  it('should clone an object with arrays', () => {
+    const obj = { a: [1, 2], b: 3 };
+    const clone = deepClone(obj);
+    expect(clone).toEqual(obj);
+    expect(clone.a).not.toBe(obj.a);
+  });
+});

--- a/src/commons/test/findAndPop.spec.ts
+++ b/src/commons/test/findAndPop.spec.ts
@@ -1,0 +1,42 @@
+import { findAndPop } from '../';
+
+describe('findAndPop', () => {
+  it('should remove and return the element from the array if found', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const element = 3;
+    const result = findAndPop(arr, element);
+    expect(result).toBe(3);
+    expect(arr).toEqual([1, 2, 4, 5]);
+  });
+
+  it('should return null if the element is not found in the array', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const element = 6;
+    const result = findAndPop(arr, element);
+    expect(result).toBeNull();
+    expect(arr).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should handle objects as elements', () => {
+    const arr = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const element = { id: 2 };
+    const result = findAndPop(arr, element);
+    expect(result).toEqual({ id: 2 });
+    expect(arr).toEqual([{ id: 1 }, { id: 3 }]);
+  });
+
+  it('should handle deep nested objects as elements', () => {
+    const arr = [
+      { id: 1, nested: { value: 10 } },
+      { id: 2, nested: { value: 20 } },
+      { id: 3, nested: { value: 30 } },
+    ];
+    const element = { id: 2, nested: { value: 20 } };
+    const result = findAndPop(arr, element);
+    expect(result).toEqual({ id: 2, nested: { value: 20 } });
+    expect(arr).toEqual([
+      { id: 1, nested: { value: 10 } },
+      { id: 3, nested: { value: 30 } },
+    ]);
+  });
+});

--- a/src/commons/test/isObject.spec.ts
+++ b/src/commons/test/isObject.spec.ts
@@ -1,0 +1,33 @@
+import { isObject } from '..';
+
+describe('isObject', () => {
+  it('should return true for an object', () => {
+    const obj = { a: 1 };
+    expect(isObject(obj)).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    const obj = null;
+    expect(isObject(obj)).toBe(false);
+  });
+
+  it('should return false for a string', () => {
+    const obj = 'test';
+    expect(isObject(obj)).toBe(false);
+  });
+
+  it('should return false for a number', () => {
+    const obj = 123;
+    expect(isObject(obj)).toBe(false);
+  });
+
+  it('should return false for an array', () => {
+    const obj = [1, 2, 3];
+    expect(isObject(obj)).toBe(false);
+  });
+
+  it('should return false for a boolean', () => {
+    const obj = true;
+    expect(isObject(obj)).toBe(false);
+  });
+});

--- a/src/commons/test/isPrimitive.spec.ts
+++ b/src/commons/test/isPrimitive.spec.ts
@@ -1,0 +1,48 @@
+import { isPrimitive } from '../';
+
+describe('isPrimitive', () => {
+  it('should return true for null', () => {
+    expect(isPrimitive(null)).toBe(true);
+  });
+
+  it('should return true for boolean values', () => {
+    expect(isPrimitive(true)).toBe(true);
+    expect(isPrimitive(false)).toBe(true);
+  });
+
+  it('should return true for number values', () => {
+    expect(isPrimitive(0)).toBe(true);
+    expect(isPrimitive(1)).toBe(true);
+    expect(isPrimitive(-1)).toBe(true);
+    expect(isPrimitive(3.14)).toBe(true);
+  });
+
+  it('should return true for string values', () => {
+    expect(isPrimitive('')).toBe(true);
+    expect(isPrimitive('hello')).toBe(true);
+  });
+
+  it('should return true for symbol values', () => {
+    const symbol = Symbol();
+    expect(isPrimitive(symbol)).toBe(true);
+  });
+
+  it('should return true for undefined', () => {
+    expect(isPrimitive(undefined)).toBe(true);
+  });
+
+  it('should return true for bigint values', () => {
+    const bigint = BigInt(123);
+    expect(isPrimitive(bigint)).toBe(true);
+  });
+
+  it('should return false for non-primitive values', () => {
+    expect(isPrimitive({})).toBe(false);
+    expect(isPrimitive([])).toBe(false);
+    expect(
+      isPrimitive(() => {
+        return null;
+      })
+    ).toBe(false);
+  });
+});

--- a/src/deepCloneReplace/index.ts
+++ b/src/deepCloneReplace/index.ts
@@ -1,3 +1,4 @@
+import { deepClone } from '../commons/deepClone';
 import { RecursivePartial } from '../types/common-types';
 
 type Primitive = string | number | boolean;
@@ -29,30 +30,6 @@ export function merge<T>(target: T, source: SourceType) {
       }
     }
   }
-}
-
-// Function to deep clone an object
-export function deepClone<T>(obj: T): T {
-  if (obj === null || typeof obj !== 'object') {
-    return obj;
-  }
-
-  if (Array.isArray(obj)) {
-    const arrCopy = [];
-    for (const item of obj) {
-      arrCopy.push(deepClone(item));
-    }
-    return arrCopy as unknown as T;
-  }
-
-  const objCopy: { [K in keyof T]: T[K] } = {} as { [K in keyof T]: T[K] };
-  for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      objCopy[key] = deepClone(obj[key]);
-    }
-  }
-
-  return objCopy as T;
 }
 
 // Function takes a possible nested object and a possible nested key value pair and returns a deep clone of the object with the key value pair replaced. If the key does not exist in the object, add it to the new object.

--- a/src/deepCloneReplace/test/index.spec.ts
+++ b/src/deepCloneReplace/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { merge, deepClone, deepCloneReplace } from '..';
+import { merge, deepCloneReplace } from '..';
 
 describe('deepCloneReplace', () => {
   describe('merge', () => {
@@ -44,36 +44,6 @@ describe('deepCloneReplace', () => {
       merge(target, source);
       expect(typeof target['a']).toBe('object');
       expect(target['a']).toEqual({ b: 1 });
-    });
-  });
-
-  describe('deepClone', () => {
-    it('should clone a simple object', () => {
-      const obj = { a: 1 };
-      const clone = deepClone(obj);
-      expect(clone).toEqual(obj);
-      expect(clone).not.toBe(obj);
-    });
-
-    it('should clone a nested object', () => {
-      const obj = { a: { b: 1 } };
-      const clone = deepClone(obj);
-      expect(clone).toEqual(obj);
-      expect(clone.a).not.toBe(obj.a);
-    });
-
-    it('should clone an array', () => {
-      const arr = [1, 2, 3];
-      const clone = deepClone(arr);
-      expect(clone).toEqual(arr);
-      expect(clone).not.toBe(arr);
-    });
-
-    it('should clone an object with arrays', () => {
-      const obj = { a: [1, 2], b: 3 };
-      const clone = deepClone(obj);
-      expect(clone).toEqual(obj);
-      expect(clone.a).not.toBe(obj.a);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export { deepCloneReplace, deepClone, merge } from './deepCloneReplace';
+export { deepCloneReplace, merge } from './deepCloneReplace';
 export { getDifference } from './getDifference';
 export { areObjectsEqual } from './areObjectsEqual';
+export * from './commons';


### PR DESCRIPTION
### Description of change

This PR introduces a new utility function,`areArraysEqual`, which checks if two arrays are equal. The function supports both strict and loose comparison modes, allowing for flexible array comparison based on the use case.

### Changes
- New Function: `areArraysEqual<T>(array1: T[], array2: T[], strictMode = false): boolean`
  - Strict Mode: When `strictMode` is `true`, the function performs a strict comparison of array elements, ensuring both type and value equality.
  - Loose Mode: When `strictMode` is `false`, the function performs a loose comparison of array elements, allowing for type coercion and handling nested structures.

Tickets: [#188271985](https://www.pivotaltracker.com/story/show/188271985)